### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly checks for two ecosystems:
  - `maven` — covers `pom.xml` and the Maven wrapper (`.mvn/wrapper/maven-wrapper.properties`)
  - `github-actions` — covers `.github/workflows/**`
- Default one-PR-per-dependency behavior; `open-pull-requests-limit` raised to 10 to give headroom for the initial wave of bumps.

Stacked on top of #16 (SHA pinning) so Dependabot can keep the SHA-pinned actions current and update the trailing version comment automatically. Once #16 is merged, retarget this PR's base to `master` (or merge in order).

## Test plan

- [ ] After merge: open the repo's *Insights → Dependency graph → Dependabot* tab and verify both ecosystems appear with a recent "Last checked" timestamp
- [ ] Confirm Dependabot opens PRs for any stale Maven dependencies in `pom.xml`
- [ ] Confirm Dependabot opens SHA-pinned PRs when the next release of any tracked action ships