### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Re-applies the Dependabot config that was "merged" via #17 but never actually landed on `master` (PR #17 merged into the stacked parent branch instead of `master` due to a base-retarget race).
- Adds `.github/dependabot.yml` with weekly checks for:
  - `maven` — `pom.xml` and the Maven wrapper
  - `github-actions` — `.github/workflows/**`

Same content as #17, just targeting `master` directly.

## Test plan

- [ ] After merge: *Insights → Dependency graph → Dependabot* tab shows both ecosystems with a "Last checked" timestamp
- [ ] Dependabot opens PRs for any stale Maven dependencies