### PR TITLE
fix: avoid NPE in factory close() when channel/connection were never opened

### DIFF
--- a/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqEventListenerProviderFactory.java
+++ b/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqEventListenerProviderFactory.java
@@ -112,18 +112,37 @@ public class RabbitMqEventListenerProviderFactory implements EventListenerProvid
 
     @Override
     public void close() {
-        try {
-            channel.close();
-            connection.close();
-        }
-        catch (IOException | TimeoutException e) {
-            log.error("keycloak-to-rabbitmq ERROR on close", e);
-        }
+        closeChannel();
+        closeConnection();
     }
 
     @Override
     public String getId() {
         return "keycloak-to-rabbitmq";
+    }
+
+    private void closeChannel() {
+        if (channel == null || !channel.isOpen()) {
+            return;
+        }
+        try {
+            channel.close();
+        }
+        catch (IOException | TimeoutException e) {
+            log.error("keycloak-to-rabbitmq ERROR closing channel", e);
+        }
+    }
+
+    private void closeConnection() {
+        if (connection == null || !connection.isOpen()) {
+            return;
+        }
+        try {
+            connection.close();
+        }
+        catch (IOException e) {
+            log.error("keycloak-to-rabbitmq ERROR closing connection", e);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- During commands like `kc.sh export`, the factory is initialized but `create()` is never called, so `channel` and `connection` stay `null`. Shutdown then triggered a `NullPointerException` in `RabbitMqEventListenerProviderFactory.close()`.
- Split `close()` into `closeChannel()` and `closeConnection()` with null and `isOpen()` checks so each resource is released independently. This also keeps the connection close from being skipped when the channel close fails.

## Reproduction
Running `kc.sh export` with the plugin deployed produced:

```
ERROR [io.quarkus.runtime.StartupContext] Running a shutdown task failed [Error Occurred After Shutdown]:
java.lang.NullPointerException: Cannot invoke "com.rabbitmq.client.Channel.close()" because "this.channel" is null
    at com.github.aznamier.keycloak.event.provider.RabbitMqEventListenerProviderFactory.close(RabbitMqEventListenerProviderFactory.java:116)
```

The export itself completed successfully; the error happened only during the post-export shutdown.

## Test plan
- [ ] `kc.sh export` no longer logs the shutdown NPE with the plugin deployed
- [ ] Normal runtime (events flowing through RabbitMQ) still shuts down cleanly